### PR TITLE
8: Sprint 0 Keycloak realm and JWT validation baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,13 @@ LOG_LEVEL=INFO
 SECRET_KEY=changeme-long-random-string
 
 # Frontend OIDC contract
+# NOTE: VITE_KEYCLOAK_URL uses the host-accessible address (http://localhost:8080)
+# while KEYCLOAK_ISSUER_URL uses the container-internal hostname (keycloak).
+# Both are correct for local dev: the browser never calls keycloak:8080 directly,
+# and the backend never resolves localhost:8080 inside the container network.
+# Tokens issued by Keycloak will carry "iss": "http://localhost:8080/realms/dpp"
+# when accessed via localhost, so set KEYCLOAK_ISSUER_URL accordingly in
+# non-Docker local runs.  For Docker Compose the container hostname is used.
 VITE_KEYCLOAK_URL=http://localhost:8080
 VITE_KEYCLOAK_REALM=dpp
 VITE_KEYCLOAK_CLIENT_ID=dpp-frontend
@@ -25,6 +32,7 @@ VITE_KEYCLOAK_CLIENT_ID=dpp-frontend
 KEYCLOAK_DB_NAME=dpp
 KEYCLOAK_DB_USER=dpp
 KEYCLOAK_DB_PASSWORD=changeme
+# Keycloak admin credentials — CHANGE BEFORE ANY NON-LOCAL DEPLOYMENT
 KEYCLOAK_ADMIN_USER=admin
 KEYCLOAK_ADMIN_PASSWORD=admin
 

--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,20 @@ MONGODB_URI=mongodb://mongo:27017/dpp
 MINIO_ENDPOINT=minio:9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=changeme
+KEYCLOAK_FRONTEND_CLIENT_ID=dpp-frontend
+KEYCLOAK_BACKEND_CLIENT_ID=dpp-backend
 KEYCLOAK_ISSUER_URL=http://keycloak:8080/realms/dpp
 JWT_AUDIENCE=dpp-backend
+JWT_ALGORITHM=RS256
+KEYCLOAK_PRELOAD_JWKS=false
 CELERY_BROKER_URL=redis://redis:6379/0
 LOG_LEVEL=INFO
 SECRET_KEY=changeme-long-random-string
+
+# Frontend OIDC contract
+VITE_KEYCLOAK_URL=http://localhost:8080
+VITE_KEYCLOAK_REALM=dpp
+VITE_KEYCLOAK_CLIENT_ID=dpp-frontend
 
 # Keycloak database
 KEYCLOAK_DB_NAME=dpp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local environment
 .env
+.aas_py/
 .venv/
 venv/
 .vscode/settings.json

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -26,11 +26,13 @@
 - Keep cross-service credentials/defaults consistent so stack startup does not require hidden bootstrap steps.
 - When one PostgreSQL container serves multiple consumers, provision extra DBs/roles via init scripts in `/docker-entrypoint-initdb.d/`.
 - Include observability and reproducibility concerns in Docker-first decisions from the start.
+- On Docker Desktop setups where Traefik Docker provider repeatedly fails against the daemon API, use Traefik file provider with static `dynamic.yml` routes for local development instead of Docker provider discovery.
 
 ## Backend and Python
 
 - Avoid import-time logging side effects; initialize logging during app startup.
 - Add explicit `__init__.py` files in new Python package paths to keep pytest/mypy/ruff discovery predictable.
+- Standardize backend local tooling on a dedicated repository-root virtual environment (for example `.aas_py`) and invoke tools through that interpreter to avoid global-package drift.
 
 ## Database and Migrations
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -56,3 +56,13 @@
 
 - If MCP active PR lookup fails, fall back to `gh pr view <N> --json reviews,comments` plus `gh api repos/<owner>/<repo>/pulls/<N>/comments`.
 - For true unresolved-review detection, query GraphQL `reviewThreads`; pull-review comments alone do not include thread resolution state.
+- In sandboxed CI environments, the GitHub REST and GraphQL APIs may be blocked by a DNS monitoring proxy even when `GITHUB_TOKEN` is set; in that case, deliver the review as a structured response and commit the findings to `LEARNINGS.md`.
+
+## Authentication and JWT Validation
+
+- Pin `jwt_algorithm` to an explicit allowlist (e.g., `["RS256"]`) in `jwt.decode()` rather than making it freely configurable via an env var, which could be set to `"none"` or a weak algorithm.
+- Never commit client secrets in realm JSON files, even for development; use env-var substitution or auto-generate secrets at first startup.
+- FastAPI `@app.on_event("startup")` is deprecated since FastAPI 0.93; use the `lifespan` context manager pattern instead.
+- When `lru_cache` is used on FastAPI dependencies (e.g., `get_token_validator`), tests must call `.cache_clear()` before and after to prevent cross-test pollution.
+- Traefik label-based routing in `docker-compose.yml` is silently ignored when only the `file` provider is configured; routing must be in `dynamic.yml` in that case — do not duplicate route definitions in both places.
+- Use `service_healthy` (not `service_started`) for the Keycloak `depends_on` condition to avoid the backend connecting before Keycloak is ready to serve tokens.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the planning artifacts and implementation scaffold for 
 
 - Sprint 0 foundation is in place for infrastructure, backend, frontend, and CI quality gates.
 - The backend includes a runnable FastAPI scaffold and an Alembic PostgreSQL migration baseline.
+- Keycloak realm import and backend JWT validation foundations are prepared for upcoming auth flows.
 - The frontend includes a React/TypeScript scaffold with lint, typecheck, format, test, and build tooling.
 - Product features are intentionally deferred to follow-up sprint issues.
 
@@ -16,6 +17,7 @@ This repository contains the planning artifacts and implementation scaffold for 
 - Core local platform via Docker Compose (`frontend`, `backend`, `postgres`, `mongo`, `minio`, `keycloak`, `traefik`).
 - Backend scaffold under `backend/app` with health/config foundations.
 - PostgreSQL migration baseline via Alembic in `backend/app/infrastructure/db/migrations`.
+- Keycloak realm baseline in `infra/keycloak/realm-import/dpp-realm.json` and backend JWT validation primitives in `backend/app/infrastructure/keycloak`.
 - Frontend foundation with Vite/React/TypeScript tooling.
 - CI baseline at `.github/workflows/ci.yml` for backend and frontend verification.
 
@@ -29,9 +31,13 @@ This repository contains the planning artifacts and implementation scaffold for 
 
 1. Read the planning overview in `doc/planning/README.md`.
 2. Use folder READMEs in `backend/`, `frontend/`, and `infra/` for module boundaries.
-3. Copy `.env.example` to `.env`.
-4. Start the stack: `docker compose up -d`.
-5. Stop the stack: `docker compose down` (or `docker compose down -v` to remove persisted data).
+3. Create a local Python virtual environment for backend work:
+	- `python -m venv .aas_py`
+4. Install backend dependencies with the venv interpreter:
+	- `.\.aas_py\Scripts\python -m pip install -e ".\backend[test]"`
+5. Copy `.env.example` to `.env`.
+6. Start the stack: `docker compose up -d`.
+7. Stop the stack: `docker compose down` (or `docker compose down -v` to remove persisted data).
 
 ## Local Core Stack
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -37,14 +37,23 @@ backend/
   - `GET /health/ready`
 - Initial backend tests for settings and health routes.
 - Alembic migration baseline for future PostgreSQL-backed models.
+- Keycloak JWT validation primitives in `app/infrastructure/keycloak/` and FastAPI dependency helpers in `app/dependencies.py`.
 
 ## Local run
+
+The recommended setup uses the repository-root virtual environment `.aas_py`.
+
+From the repository root:
+
+```powershell
+python -m venv .aas_py
+.\.aas_py\Scripts\python -m pip install -e ".\backend[test]"
+```
 
 From the `backend/` folder:
 
 ```powershell
-pip install -e .[test]
-python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+..\.aas_py\Scripts\python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 ## Local tests
@@ -52,7 +61,7 @@ python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 From the `backend/` folder:
 
 ```powershell
-python -m pytest
+..\.aas_py\Scripts\python -m pytest
 ```
 
 ## Local migrations
@@ -62,10 +71,9 @@ The backend uses Alembic for relational schema migrations.
 From the `backend/` folder:
 
 ```powershell
-pip install -e .[test]
-python -m alembic current
-python -m alembic revision -m "describe change"
-python -m alembic upgrade head
+..\.aas_py\Scripts\python -m alembic current
+..\.aas_py\Scripts\python -m alembic revision -m "describe change"
+..\.aas_py\Scripts\python -m alembic upgrade head
 ```
 
 Notes:
@@ -73,3 +81,26 @@ Notes:
 - Alembic reads `DATABASE_URL` from the repository `.env` file via `app.config.Settings`.
 - Async PostgreSQL URLs (`postgresql+asyncpg://...`) are converted automatically to a synchronous `psycopg` URL for migration runs.
 - Migration scripts belong in `app/infrastructure/db/migrations/versions/`.
+
+## Local authentication baseline
+
+The backend now carries the configuration contract and validation primitives for Keycloak-issued JWTs.
+
+Required environment variables:
+
+- `KEYCLOAK_ISSUER_URL`
+- `JWT_AUDIENCE`
+- `JWT_ALGORITHM`
+- `KEYCLOAK_FRONTEND_CLIENT_ID`
+- `KEYCLOAK_BACKEND_CLIENT_ID`
+
+Derived endpoints:
+
+- OpenID configuration: `KEYCLOAK_ISSUER_URL/.well-known/openid-configuration`
+- JWKS: `KEYCLOAK_ISSUER_URL/protocol/openid-connect/certs`
+
+Implementation notes:
+
+- `app.infrastructure.keycloak.auth.KeycloakTokenValidator` verifies signature, issuer, audience, and expiry.
+- `app.dependencies.get_current_user` and `app.dependencies.require_roles(...)` are ready for future protected routers such as `/users/me`.
+- The local development realm import is defined in `../infra/keycloak/realm-import/dpp-realm.json`.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,16 +51,22 @@ class Settings(BaseSettings):
         return self.database_url
 
     @property
+    def _keycloak_issuer_base_url(self) -> str:
+        """Return the issuer URL normalized for building derived Keycloak endpoints."""
+
+        return self.keycloak_issuer_url.strip().rstrip("/")
+
+    @property
     def keycloak_openid_configuration_url(self) -> str:
         """Return the realm OpenID configuration endpoint."""
 
-        return f"{self.keycloak_issuer_url.rstrip('/').rstrip()}/.well-known/openid-configuration"
+        return f"{self._keycloak_issuer_base_url}/.well-known/openid-configuration"
 
     @property
     def keycloak_jwks_url(self) -> str:
         """Return the Keycloak JWKS endpoint derived from the issuer URL."""
 
-        return f"{self.keycloak_issuer_url.rstrip('/').rstrip()}/protocol/openid-connect/certs"
+        return f"{self._keycloak_issuer_base_url}/protocol/openid-connect/certs"
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,21 @@ class Settings(BaseSettings):
         default="postgresql+asyncpg://dpp:changeme@localhost:5432/dpp",
         alias="DATABASE_URL",
     )
+    keycloak_issuer_url: str = Field(
+        default="http://keycloak:8080/realms/dpp",
+        alias="KEYCLOAK_ISSUER_URL",
+    )
+    jwt_audience: str = Field(default="dpp-backend", alias="JWT_AUDIENCE")
+    jwt_algorithm: str = Field(default="RS256", alias="JWT_ALGORITHM")
+    keycloak_frontend_client_id: str = Field(
+        default="dpp-frontend",
+        alias="KEYCLOAK_FRONTEND_CLIENT_ID",
+    )
+    keycloak_backend_client_id: str = Field(
+        default="dpp-backend",
+        alias="KEYCLOAK_BACKEND_CLIENT_ID",
+    )
+    keycloak_preload_jwks: bool = Field(default=False, alias="KEYCLOAK_PRELOAD_JWKS")
 
     model_config = SettingsConfigDict(
         env_file=(".env", "../.env"),
@@ -34,6 +49,18 @@ class Settings(BaseSettings):
             return self.database_url.replace("postgresql+asyncpg://", "postgresql+psycopg://", 1)
 
         return self.database_url
+
+    @property
+    def keycloak_openid_configuration_url(self) -> str:
+        """Return the realm OpenID configuration endpoint."""
+
+        return f"{self.keycloak_issuer_url.rstrip('/').rstrip()}/.well-known/openid-configuration"
+
+    @property
+    def keycloak_jwks_url(self) -> str:
+        """Return the Keycloak JWKS endpoint derived from the issuer URL."""
+
+        return f"{self.keycloak_issuer_url.rstrip('/').rstrip()}/protocol/openid-connect/certs"
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -47,7 +47,17 @@ def get_current_user(
 
 
 def require_roles(required_roles: Sequence[str]):
-    """Require the current user to hold at least one of the provided realm roles."""
+    """Require the current user to hold at least one of the provided realm roles.
+
+    Raises ``ValueError`` at decoration time when ``required_roles`` is empty to
+    prevent accidentally granting all authenticated users access.
+    """
+
+    if not required_roles:
+        raise ValueError(
+            "require_roles() called with an empty role list. "
+            "Use get_current_user directly if no role gate is needed."
+        )
 
     required_role_set = frozenset(required_roles)
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,63 @@
+"""FastAPI dependency helpers for authentication and role checks."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Sequence
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.config import get_settings
+from app.infrastructure.keycloak.auth import KeycloakTokenValidator, TokenValidationError
+from app.infrastructure.keycloak.models import CurrentUser
+
+
+http_bearer = HTTPBearer(auto_error=False)
+
+
+@lru_cache(maxsize=1)
+def get_token_validator() -> KeycloakTokenValidator:
+    """Build and cache the token validator shared across requests."""
+
+    return KeycloakTokenValidator(get_settings())
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(http_bearer),
+    token_validator: KeycloakTokenValidator = Depends(get_token_validator),
+) -> CurrentUser:
+    """Validate a bearer token and expose the authenticated user context."""
+
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing bearer token.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        return token_validator.validate_token(credentials.credentials)
+    except TokenValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid access token.",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+
+def require_roles(required_roles: Sequence[str]):
+    """Require the current user to hold at least one of the provided realm roles."""
+
+    required_role_set = frozenset(required_roles)
+
+    def dependency(current_user: CurrentUser = Depends(get_current_user)) -> CurrentUser:
+        if required_role_set and not any(current_user.has_role(role) for role in required_role_set):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role membership.",
+            )
+
+        return current_user
+
+    return dependency

--- a/backend/app/infrastructure/keycloak/__init__.py
+++ b/backend/app/infrastructure/keycloak/__init__.py
@@ -1,0 +1,1 @@
+"""Keycloak integration primitives."""

--- a/backend/app/infrastructure/keycloak/auth.py
+++ b/backend/app/infrastructure/keycloak/auth.py
@@ -11,6 +11,12 @@ from app.config import Settings
 from app.infrastructure.keycloak.models import CurrentUser
 
 
+# Algorithms that are safe to use with asymmetric Keycloak-issued tokens.
+# Accepting ``none`` or symmetric algorithms (e.g. ``HS256``) would allow
+# an attacker to forge tokens, so we restrict to RS256 only.
+_ALLOWED_ALGORITHMS: frozenset[str] = frozenset({"RS256"})
+
+
 class TokenValidationError(ValueError):
     """Raised when a JWT cannot be validated against the configured Keycloak realm."""
 
@@ -63,14 +69,27 @@ class KeycloakTokenValidator:
     def validate_token(self, token: str) -> CurrentUser:
         """Validate a JWT and return a normalized authenticated user model."""
 
+        # Guard against algorithm confusion attacks: reject any algorithm that
+        # is not on the explicit allowlist before reaching jwt.decode().
+        algorithm = self._settings.jwt_algorithm
+        if algorithm not in _ALLOWED_ALGORITHMS:
+            raise TokenValidationError(
+                f"Unsupported JWT algorithm configured: {algorithm!r}. "
+                f"Allowed: {sorted(_ALLOWED_ALGORITHMS)}"
+            )
+
+        # Normalize the issuer URL to ensure trailing-slash variants do not
+        # cause spurious validation mismatches.
+        normalized_issuer = self._settings.keycloak_issuer_url.strip().rstrip("/")
+
         try:
             signing_key = self._signing_key_resolver.resolve_signing_key(token)
             claims = jwt.decode(
                 token,
                 key=signing_key,
-                algorithms=[self._settings.jwt_algorithm],
+                algorithms=[algorithm],
                 audience=self._settings.jwt_audience,
-                issuer=self._settings.keycloak_issuer_url,
+                issuer=normalized_issuer,
             )
             return CurrentUser.from_claims(claims)
         except (InvalidTokenError, ValueError) as exc:

--- a/backend/app/infrastructure/keycloak/auth.py
+++ b/backend/app/infrastructure/keycloak/auth.py
@@ -1,0 +1,77 @@
+"""Keycloak JWT validation primitives used by FastAPI dependencies."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import jwt
+from jwt import InvalidTokenError, PyJWKClient
+
+from app.config import Settings
+from app.infrastructure.keycloak.models import CurrentUser
+
+
+class TokenValidationError(ValueError):
+    """Raised when a JWT cannot be validated against the configured Keycloak realm."""
+
+
+class SigningKeyResolver(Protocol):
+    """Resolve the signing key for a given JWT."""
+
+    def prime(self) -> None:
+        """Warm any internal caches before the first validation attempt."""
+
+    def resolve_signing_key(self, token: str) -> Any:
+        """Resolve the signing key for the provided token."""
+
+
+class PyJWKSigningKeyResolver:
+    """Resolve signing keys from the Keycloak JWKS endpoint using PyJWT."""
+
+    def __init__(self, jwks_url: str) -> None:
+        self._jwk_client = PyJWKClient(jwks_url)
+
+    def prime(self) -> None:
+        """Populate the underlying JWKS cache before request handling begins."""
+
+        self._jwk_client.get_signing_keys()
+
+    def resolve_signing_key(self, token: str) -> Any:
+        """Resolve the signing key for the provided token."""
+
+        return self._jwk_client.get_signing_key_from_jwt(token).key
+
+
+class KeycloakTokenValidator:
+    """Validate Keycloak-issued access tokens and normalize their claim set."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        signing_key_resolver: SigningKeyResolver | None = None,
+    ) -> None:
+        self._settings = settings
+        self._signing_key_resolver = signing_key_resolver or PyJWKSigningKeyResolver(
+            settings.keycloak_jwks_url
+        )
+
+    def prime_jwks_cache(self) -> None:
+        """Warm the JWKS cache for the configured Keycloak realm."""
+
+        self._signing_key_resolver.prime()
+
+    def validate_token(self, token: str) -> CurrentUser:
+        """Validate a JWT and return a normalized authenticated user model."""
+
+        try:
+            signing_key = self._signing_key_resolver.resolve_signing_key(token)
+            claims = jwt.decode(
+                token,
+                key=signing_key,
+                algorithms=[self._settings.jwt_algorithm],
+                audience=self._settings.jwt_audience,
+                issuer=self._settings.keycloak_issuer_url,
+            )
+            return CurrentUser.from_claims(claims)
+        except (InvalidTokenError, ValueError) as exc:
+            raise TokenValidationError("Token validation failed.") from exc

--- a/backend/app/infrastructure/keycloak/models.py
+++ b/backend/app/infrastructure/keycloak/models.py
@@ -1,0 +1,44 @@
+"""Request-scoped identity models derived from Keycloak JWT claims."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentUser:
+    """Normalized user context extracted from a validated access token."""
+
+    subject: str
+    roles: tuple[str, ...]
+    tenant_id: str | None = None
+    preferred_username: str | None = None
+    email: str | None = None
+    claims: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_claims(cls, claims: Mapping[str, Any]) -> "CurrentUser":
+        """Build a stable identity model from raw JWT claims."""
+
+        subject = str(claims.get("sub", "")).strip()
+        if not subject:
+            raise ValueError("Token payload is missing the 'sub' claim.")
+
+        realm_access = claims.get("realm_access") or {}
+        raw_roles = realm_access.get("roles") or []
+        roles = tuple(dict.fromkeys(str(role) for role in raw_roles if str(role).strip()))
+
+        return cls(
+            subject=subject,
+            roles=roles,
+            tenant_id=claims.get("tenant_id"),
+            preferred_username=claims.get("preferred_username"),
+            email=claims.get("email"),
+            claims=dict(claims),
+        )
+
+    def has_role(self, role: str) -> bool:
+        """Return whether the user holds the given realm role."""
+
+        return role in self.roles

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 """FastAPI app factory and application entrypoint."""
 
 import logging
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
 from fastapi import FastAPI
 
@@ -17,22 +19,28 @@ def create_app() -> FastAPI:
     """Build and configure the FastAPI application instance."""
     settings = get_settings()
 
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
+        """Configure logging and optionally warm the JWKS cache on startup."""
+        configure_logging(settings)
+        if settings.keycloak_preload_jwks:
+            try:
+                get_token_validator().prime_jwks_cache()
+            except Exception:
+                logger.warning(
+                    "Failed to preload Keycloak JWKS cache during startup.",
+                    exc_info=True,
+                )
+        yield
+
     app = FastAPI(
         title=settings.service_name,
         version="0.1.0",
         openapi_url=f"{settings.api_v1_prefix}/openapi.json",
         docs_url="/docs",
         redoc_url="/redoc",
+        lifespan=lifespan,
     )
-
-    @app.on_event("startup")
-    def setup_logging() -> None:
-        configure_logging(settings)
-        if settings.keycloak_preload_jwks:
-            try:
-                get_token_validator().prime_jwks_cache()
-            except Exception:
-                logger.warning("Failed to preload Keycloak JWKS cache during startup.", exc_info=True)
 
     app.include_router(health_router)
     return app

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,16 @@
 """FastAPI app factory and application entrypoint."""
 
+import logging
+
 from fastapi import FastAPI
 
 from app.api.health import router as health_router
 from app.config import get_settings
+from app.dependencies import get_token_validator
 from app.logging import configure_logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def create_app() -> FastAPI:
@@ -22,6 +28,11 @@ def create_app() -> FastAPI:
     @app.on_event("startup")
     def setup_logging() -> None:
         configure_logging(settings)
+        if settings.keycloak_preload_jwks:
+            try:
+                get_token_validator().prime_jwks_cache()
+            except Exception:
+                logger.warning("Failed to preload Keycloak JWKS cache during startup.", exc_info=True)
 
     app.include_router(health_router)
     return app

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "alembic>=1.14,<2.0",
     "asyncpg>=0.29,<1.0",
     "fastapi>=0.110,<1.0",
+    "pyjwt[crypto]>=2.9,<3.0",
     "uvicorn[standard]>=0.27,<1.0",
     "pydantic>=2.6,<3.0",
     "pydantic-settings>=2.2,<3.0",
@@ -22,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=8.0,<9.0",
+    "ruff>=0.9,<1.0",
     "httpx>=0.27,<1.0",
 ]
 

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -10,6 +10,11 @@ def test_settings_use_env_override(monkeypatch) -> None:
     monkeypatch.setenv("DPP_ENVIRONMENT", "test")
     monkeypatch.setenv("DPP_API_V1_PREFIX", "/api/custom")
     monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@db:5432/dpp")
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "http://keycloak:8080/realms/test")
+    monkeypatch.setenv("JWT_AUDIENCE", "test-audience")
+    monkeypatch.setenv("JWT_ALGORITHM", "RS256")
+    monkeypatch.setenv("KEYCLOAK_FRONTEND_CLIENT_ID", "test-frontend")
+    monkeypatch.setenv("KEYCLOAK_BACKEND_CLIENT_ID", "test-backend")
 
     settings = get_settings()
 
@@ -18,6 +23,19 @@ def test_settings_use_env_override(monkeypatch) -> None:
     assert settings.api_v1_prefix == "/api/custom"
     assert settings.database_url == "postgresql+asyncpg://test:test@db:5432/dpp"
     assert settings.alembic_database_url == "postgresql+psycopg://test:test@db:5432/dpp"
+    assert settings.keycloak_issuer_url == "http://keycloak:8080/realms/test"
+    assert settings.jwt_audience == "test-audience"
+    assert settings.jwt_algorithm == "RS256"
+    assert settings.keycloak_frontend_client_id == "test-frontend"
+    assert settings.keycloak_backend_client_id == "test-backend"
+    assert (
+        settings.keycloak_openid_configuration_url
+        == "http://keycloak:8080/realms/test/.well-known/openid-configuration"
+    )
+    assert (
+        settings.keycloak_jwks_url
+        == "http://keycloak:8080/realms/test/protocol/openid-connect/certs"
+    )
 
     get_settings.cache_clear()
 
@@ -29,3 +47,15 @@ def test_alembic_database_url_passthrough_for_non_asyncpg(monkeypatch) -> None:
     settings = Settings()
 
     assert settings.alembic_database_url == "postgresql+psycopg://test:test@db:5432/dpp"
+
+
+def test_keycloak_jwks_url_trims_trailing_slash() -> None:
+    """Keycloak-derived URLs should remain stable when issuer values include a trailing slash."""
+    settings = Settings(keycloak_issuer_url="http://keycloak:8080/realms/dpp/")
+
+    assert settings.keycloak_openid_configuration_url == (
+        "http://keycloak:8080/realms/dpp/.well-known/openid-configuration"
+    )
+    assert settings.keycloak_jwks_url == (
+        "http://keycloak:8080/realms/dpp/protocol/openid-connect/certs"
+    )

--- a/backend/tests/unit/test_keycloak_auth.py
+++ b/backend/tests/unit/test_keycloak_auth.py
@@ -1,0 +1,95 @@
+"""Unit tests for Keycloak JWT validation and authorization helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+from app.config import Settings
+from app.dependencies import require_roles
+from app.infrastructure.keycloak.auth import KeycloakTokenValidator
+from app.infrastructure.keycloak.models import CurrentUser
+
+
+class StaticSigningKeyResolver:
+    """Deterministic signing key resolver for unit tests."""
+
+    def __init__(self, signing_key: str) -> None:
+        self._signing_key = signing_key
+
+    def prime(self) -> None:
+        """No-op cache warmup for static test keys."""
+
+    def resolve_signing_key(self, token: str) -> str:
+        """Return the same key for every token under test."""
+
+        del token
+        return self._signing_key
+
+
+def test_current_user_extracts_roles_from_realm_access() -> None:
+    """CurrentUser should normalize subject, roles, and tenant context from claims."""
+
+    current_user = CurrentUser.from_claims(
+        {
+            "sub": "user-123",
+            "tenant_id": "tenant-a",
+            "preferred_username": "alice",
+            "email": "alice@example.com",
+            "realm_access": {"roles": ["ADMIN", "ADMIN", "AUDITOR"]},
+        }
+    )
+
+    assert current_user.subject == "user-123"
+    assert current_user.roles == ("ADMIN", "AUDITOR")
+    assert current_user.tenant_id == "tenant-a"
+    assert current_user.preferred_username == "alice"
+    assert current_user.email == "alice@example.com"
+
+
+def test_token_validator_returns_current_user_for_valid_token() -> None:
+    """KeycloakTokenValidator should accept a valid token and return normalized user context."""
+
+    signing_key = "unit-test-secret-with-sufficient-length"
+    settings = Settings(
+        keycloak_issuer_url="https://issuer.example/realms/dpp",
+        jwt_audience="dpp-backend",
+        jwt_algorithm="HS256",
+    )
+    validator = KeycloakTokenValidator(
+        settings,
+        signing_key_resolver=StaticSigningKeyResolver(signing_key),
+    )
+    token = jwt.encode(
+        {
+            "sub": "user-123",
+            "iss": "https://issuer.example/realms/dpp",
+            "aud": "dpp-backend",
+            "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+            "realm_access": {"roles": ["SUPPLIER"]},
+            "tenant_id": "tenant-a",
+        },
+        key=signing_key,
+        algorithm="HS256",
+    )
+
+    current_user = validator.validate_token(token)
+
+    assert current_user.subject == "user-123"
+    assert current_user.roles == ("SUPPLIER",)
+    assert current_user.tenant_id == "tenant-a"
+
+
+def test_require_roles_rejects_users_without_matching_role() -> None:
+    """Role dependencies should reject users that lack the required realm role."""
+
+    dependency = require_roles(["ADMIN"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        dependency(CurrentUser(subject="user-123", roles=("SUPPLIER",)))
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Insufficient role membership."

--- a/backend/tests/unit/test_keycloak_auth.py
+++ b/backend/tests/unit/test_keycloak_auth.py
@@ -1,17 +1,49 @@
-"""Unit tests for Keycloak JWT validation and authorization helpers."""
+"""Unit tests for Keycloak JWT validation and authorization helpers.
+
+Scope
+-----
+- ``CurrentUser`` claim normalization
+- ``KeycloakTokenValidator`` happy-path and every failure branch
+- ``require_roles`` allow-path, reject-path, and empty-list guard
+- ``get_current_user`` FastAPI dependency (missing / wrong-scheme bearer)
+- ``lru_cache`` isolation: caches are cleared after every test to prevent
+  stale instances leaking between test cases.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import jwt
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
-from app.config import Settings
-from app.dependencies import require_roles
-from app.infrastructure.keycloak.auth import KeycloakTokenValidator
+from app.config import Settings, get_settings
+from app.dependencies import get_current_user, get_token_validator, require_roles
+from app.infrastructure.keycloak.auth import KeycloakTokenValidator, TokenValidationError
 from app.infrastructure.keycloak.models import CurrentUser
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clear_lru_caches() -> None:
+    """Clear module-level LRU caches before and after each test.
+
+    ``get_token_validator`` and ``get_settings`` are cached singletons; without
+    a teardown step their instances bleed across test cases, leading to subtle
+    ordering-dependent failures.
+    """
+    get_token_validator.cache_clear()
+    get_settings.cache_clear()
+    yield
+    get_token_validator.cache_clear()
+    get_settings.cache_clear()
 
 
 class StaticSigningKeyResolver:
@@ -51,17 +83,23 @@ def test_current_user_extracts_roles_from_realm_access() -> None:
 
 
 def test_token_validator_returns_current_user_for_valid_token() -> None:
-    """KeycloakTokenValidator should accept a valid token and return normalized user context."""
+    """KeycloakTokenValidator should accept a valid RS256 token and return normalized user context.
 
-    signing_key = "unit-test-secret-with-sufficient-length"
+    A real RSA key pair is generated in-process so no external Keycloak is required.
+    """
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
     settings = Settings(
         keycloak_issuer_url="https://issuer.example/realms/dpp",
         jwt_audience="dpp-backend",
-        jwt_algorithm="HS256",
+        jwt_algorithm="RS256",
     )
     validator = KeycloakTokenValidator(
         settings,
-        signing_key_resolver=StaticSigningKeyResolver(signing_key),
+        signing_key_resolver=StaticSigningKeyResolver(public_key),
     )
     token = jwt.encode(
         {
@@ -72,8 +110,8 @@ def test_token_validator_returns_current_user_for_valid_token() -> None:
             "realm_access": {"roles": ["SUPPLIER"]},
             "tenant_id": "tenant-a",
         },
-        key=signing_key,
-        algorithm="HS256",
+        key=private_key,
+        algorithm="RS256",
     )
 
     current_user = validator.validate_token(token)
@@ -93,3 +131,242 @@ def test_require_roles_rejects_users_without_matching_role() -> None:
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Insufficient role membership."
+
+
+def test_require_roles_allows_user_with_matching_role() -> None:
+    """require_roles should pass through users that hold one of the required roles."""
+
+    dependency = require_roles(["SUPPLIER", "ADMIN"])
+
+    # Should not raise; returns the same CurrentUser instance unmodified.
+    user = CurrentUser(subject="user-456", roles=("SUPPLIER",))
+    result = dependency(user)
+
+    assert result is user
+
+
+def test_require_roles_raises_value_error_for_empty_list() -> None:
+    """require_roles([]) should raise ValueError immediately at decoration time.
+
+    An empty required_roles list is almost certainly a programming mistake; the
+    guard prevents silently granting all authenticated callers access.
+    """
+
+    with pytest.raises(ValueError, match="require_roles\\(\\) called with an empty role list"):
+        require_roles([])
+
+
+# ---------------------------------------------------------------------------
+# KeycloakTokenValidator — negative paths
+# ---------------------------------------------------------------------------
+
+
+def _make_rs256_validator(
+    *,
+    issuer: str = "https://issuer.example/realms/dpp",
+    audience: str = "dpp-backend",
+) -> tuple["KeycloakTokenValidator", "Any"]:
+    """Build a validator wired to an in-process RSA key pair for negative-path tests.
+
+    Returns the validator and the private key needed to sign test tokens.
+    The public key is passed to ``StaticSigningKeyResolver`` so no JWKS endpoint
+    is required.
+    """
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    settings = Settings(
+        keycloak_issuer_url=issuer,
+        jwt_audience=audience,
+        jwt_algorithm="RS256",
+    )
+    validator = KeycloakTokenValidator(
+        settings,
+        signing_key_resolver=StaticSigningKeyResolver(public_key),
+    )
+    return validator, private_key
+
+
+def test_validate_token_rejects_expired_token() -> None:
+    """validate_token should raise TokenValidationError for a token past its expiry."""
+
+    validator, private_key = _make_rs256_validator()
+    token = jwt.encode(
+        {
+            "sub": "user-expired",
+            "iss": "https://issuer.example/realms/dpp",
+            "aud": "dpp-backend",
+            # exp in the past → token is expired
+            "exp": datetime.now(tz=timezone.utc) - timedelta(seconds=30),
+            "realm_access": {"roles": []},
+        },
+        key=private_key,
+        algorithm="RS256",
+    )
+
+    with pytest.raises(TokenValidationError):
+        validator.validate_token(token)
+
+
+def test_validate_token_rejects_wrong_issuer() -> None:
+    """validate_token should reject a token whose issuer does not match the configured realm."""
+
+    validator, private_key = _make_rs256_validator()
+    token = jwt.encode(
+        {
+            "sub": "user-bad-iss",
+            "iss": "https://evil.example/realms/other",  # wrong issuer
+            "aud": "dpp-backend",
+            "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+            "realm_access": {"roles": []},
+        },
+        key=private_key,
+        algorithm="RS256",
+    )
+
+    with pytest.raises(TokenValidationError):
+        validator.validate_token(token)
+
+
+def test_validate_token_rejects_wrong_audience() -> None:
+    """validate_token should reject a token whose audience does not match the configured value."""
+
+    validator, private_key = _make_rs256_validator()
+    token = jwt.encode(
+        {
+            "sub": "user-bad-aud",
+            "iss": "https://issuer.example/realms/dpp",
+            "aud": "some-other-service",  # wrong audience
+            "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+            "realm_access": {"roles": []},
+        },
+        key=private_key,
+        algorithm="RS256",
+    )
+
+    with pytest.raises(TokenValidationError):
+        validator.validate_token(token)
+
+
+def test_validate_token_rejects_tampered_signature() -> None:
+    """validate_token should surface a TokenValidationError when the signature is invalid."""
+
+    validator, private_key = _make_rs256_validator()
+    token = jwt.encode(
+        {
+            "sub": "user-tampered",
+            "iss": "https://issuer.example/realms/dpp",
+            "aud": "dpp-backend",
+            "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+            "realm_access": {"roles": []},
+        },
+        key=private_key,
+        algorithm="RS256",
+    )
+    # Corrupt the signature portion (last segment) to simulate tampering.
+    header, payload, _ = token.split(".")
+    tampered_token = f"{header}.{payload}.invalidsignature"
+
+    with pytest.raises(TokenValidationError):
+        validator.validate_token(tampered_token)
+
+
+def test_validate_token_rejects_disallowed_algorithm() -> None:
+    """validate_token should raise TokenValidationError for any algorithm outside the allowlist.
+
+    This guards against algorithm-confusion attacks where an attacker presents a
+    ``none``-algorithm or symmetric-algorithm token to bypass signature verification.
+    """
+
+    # Configure a validator with a non-RS256 algorithm that is not on the allowlist.
+    settings = Settings(
+        keycloak_issuer_url="https://issuer.example/realms/dpp",
+        jwt_audience="dpp-backend",
+        jwt_algorithm="HS512",  # not in _ALLOWED_ALGORITHMS
+    )
+    validator = KeycloakTokenValidator(
+        settings,
+        signing_key_resolver=StaticSigningKeyResolver("dummy-key"),
+    )
+    # The token content does not matter; the guard fires before jwt.decode() is called.
+    # The dummy key is intentionally short; suppress the PyJWT key-length warning.
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        token = jwt.encode(
+            {
+                "sub": "user-alg",
+                "iss": "https://issuer.example/realms/dpp",
+                "aud": "dpp-backend",
+                "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+                "realm_access": {"roles": []},
+            },
+            key="dummy-key",
+            algorithm="HS512",
+        )
+
+    with pytest.raises(TokenValidationError, match="Unsupported JWT algorithm"):
+        validator.validate_token(token)
+
+
+# ---------------------------------------------------------------------------
+# get_current_user dependency — 401 paths
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_validator() -> "KeycloakTokenValidator":
+    """Build a validator with a static RS256 key pair for auth dependency tests."""
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    settings = Settings(
+        keycloak_issuer_url="https://issuer.example/realms/dpp",
+        jwt_audience="dpp-backend",
+        jwt_algorithm="RS256",
+    )
+    return KeycloakTokenValidator(
+        settings,
+        signing_key_resolver=StaticSigningKeyResolver(public_key),
+    )
+
+
+def test_get_current_user_returns_401_for_missing_bearer() -> None:
+    """get_current_user should return HTTP 401 when no Authorization header is present."""
+    from fastapi import Depends, FastAPI
+
+    from app.infrastructure.keycloak.models import CurrentUser as _CurrentUser
+
+    mini_app = FastAPI()
+    mini_app.dependency_overrides[get_token_validator] = _make_stub_validator
+
+    @mini_app.get("/protected")
+    def _protected(user: _CurrentUser = Depends(get_current_user)) -> dict:
+        return {"sub": user.subject}
+
+    client = TestClient(mini_app, raise_server_exceptions=False)
+    response = client.get("/protected")
+
+    assert response.status_code == 401
+
+
+def test_get_current_user_returns_401_for_invalid_scheme() -> None:
+    """get_current_user should return HTTP 401 when Authorization uses a non-Bearer scheme."""
+    from fastapi import Depends, FastAPI
+
+    from app.infrastructure.keycloak.models import CurrentUser as _CurrentUser
+
+    mini_app = FastAPI()
+    mini_app.dependency_overrides[get_token_validator] = _make_stub_validator
+
+    @mini_app.get("/protected")
+    def _protected(user: _CurrentUser = Depends(get_current_user)) -> dict:
+        return {"sub": user.subject}
+
+    client = TestClient(mini_app, raise_server_exceptions=False)
+    # Send a Basic auth header, which should be rejected with 401
+    response = client.get("/protected", headers={"Authorization": "Basic dXNlcjpwYXNz"})
+
+    assert response.status_code == 401

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,12 @@ services:
       MINIO_ENDPOINT: ${MINIO_ENDPOINT:-minio:9000}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-changeme}
+      KEYCLOAK_FRONTEND_CLIENT_ID: ${KEYCLOAK_FRONTEND_CLIENT_ID:-dpp-frontend}
+      KEYCLOAK_BACKEND_CLIENT_ID: ${KEYCLOAK_BACKEND_CLIENT_ID:-dpp-backend}
       KEYCLOAK_ISSUER_URL: ${KEYCLOAK_ISSUER_URL:-http://keycloak:8080/realms/dpp}
+      JWT_AUDIENCE: ${JWT_AUDIENCE:-dpp-backend}
+      JWT_ALGORITHM: ${JWT_ALGORITHM:-RS256}
+      KEYCLOAK_PRELOAD_JWKS: ${KEYCLOAK_PRELOAD_JWKS:-false}
     depends_on:
       postgres:
         condition: service_healthy
@@ -125,15 +130,15 @@ services:
       - dpp_public
 
   traefik:
-    image: traefik:v3.1
+    image: traefik:v3.3
     restart: unless-stopped
     command:
       - --configFile=/etc/traefik/traefik.yml
     ports:
       - "80:80"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./infra/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./infra/traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
     depends_on:
       frontend:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,9 @@ services:
         condition: service_started
       keycloak:
         condition: service_started
+    # Traefik routing is driven by the file provider (infra/traefik/dynamic.yml).
+    # These labels have no effect and are kept only as documentation for the
+    # intended routing contract should the Docker provider be re-enabled.
     labels:
       - traefik.enable=true
       - traefik.http.routers.backend.rule=Host(`${BACKEND_HOSTNAME:-api.dpp.localhost}`)
@@ -121,6 +124,9 @@ services:
     depends_on:
       backend:
         condition: service_started
+    # Traefik routing is driven by the file provider (infra/traefik/dynamic.yml).
+    # These labels have no effect and are kept only as documentation for the
+    # intended routing contract should the Docker provider be re-enabled.
     labels:
       - traefik.enable=true
       - traefik.http.routers.frontend.rule=Host(`${FRONTEND_HOSTNAME:-dpp.localhost}`)

--- a/infra/keycloak/realm-import/README.md
+++ b/infra/keycloak/realm-import/README.md
@@ -5,3 +5,18 @@ Place exported realm JSON files in this directory to auto-import them when the `
 Example file path:
 
 - `infra/keycloak/realm-import/dpp-realm.json`
+
+The repository now includes a local development baseline at `infra/keycloak/realm-import/dpp-realm.json` with:
+
+- Realm: `dpp`
+- Frontend OIDC client: `dpp-frontend` (public client, Authorization Code + PKCE)
+- Backend client: `dpp-backend` (confidential client placeholder for later service-to-service flows)
+- Realm roles: `ADMIN`, `MANUFACTURER`, `SUPPLIER`, `AUDITOR`, `CUSTOMER`
+
+Local issuer and audience contract:
+
+- Issuer: `http://keycloak:8080/realms/dpp`
+- Backend audience: `dpp-backend`
+- Frontend client ID: `dpp-frontend`
+
+This import is intended for local development only. Replace placeholder secrets and tighten client settings before production use.

--- a/infra/keycloak/realm-import/dpp-realm.json
+++ b/infra/keycloak/realm-import/dpp-realm.json
@@ -43,10 +43,12 @@
       "serviceAccountsEnabled": false,
       "redirectUris": [
         "http://dpp.localhost/*",
+        "http://localhost/*",
         "http://localhost:5173/*"
       ],
       "webOrigins": [
         "http://dpp.localhost",
+        "http://localhost",
         "http://localhost:5173"
       ],
       "attributes": {

--- a/infra/keycloak/realm-import/dpp-realm.json
+++ b/infra/keycloak/realm-import/dpp-realm.json
@@ -1,0 +1,87 @@
+{
+  "realm": "dpp",
+  "enabled": true,
+  "displayName": "Digital Product Passport",
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "rememberMe": true,
+  "roles": {
+    "realm": [
+      {
+        "name": "ADMIN",
+        "description": "Platform administrator role for local development."
+      },
+      {
+        "name": "MANUFACTURER",
+        "description": "Manufacturer tenant role."
+      },
+      {
+        "name": "SUPPLIER",
+        "description": "Supplier tenant role."
+      },
+      {
+        "name": "AUDITOR",
+        "description": "Auditor role for certification and verification flows."
+      },
+      {
+        "name": "CUSTOMER",
+        "description": "Read-oriented customer role."
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "dpp-frontend",
+      "name": "DPP Frontend",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://dpp.localhost/*",
+        "http://localhost:5173/*"
+      ],
+      "webOrigins": [
+        "http://dpp.localhost",
+        "http://localhost:5173"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "clientId": "dpp-backend",
+      "name": "DPP Backend",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "dpp-backend-dev-secret",
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "defaultClientScopes": [
+        "roles"
+      ],
+      "optionalClientScopes": [
+        "microprofile-jwt"
+      ]
+    }
+  ]
+}

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -1,0 +1,27 @@
+http:
+  routers:
+    frontend-localhost:
+      rule: Host(`localhost`)
+      entryPoints:
+        - web
+      service: frontend
+    frontend:
+      rule: Host(`dpp.localhost`)
+      entryPoints:
+        - web
+      service: frontend
+    backend:
+      rule: Host(`api.dpp.localhost`)
+      entryPoints:
+        - web
+      service: backend
+
+  services:
+    frontend:
+      loadBalancer:
+        servers:
+          - url: http://frontend:5173
+    backend:
+      loadBalancer:
+        servers:
+          - url: http://backend:8000

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -7,9 +7,9 @@ entryPoints:
     address: ":80"
 
 providers:
-  docker:
-    exposedByDefault: false
-    network: dpp_public
+  file:
+    filename: /etc/traefik/dynamic.yml
+    watch: true
 
 log:
   level: INFO


### PR DESCRIPTION
Fixes #8

This PR delivers Sprint 0 authentication foundation:
- Keycloak realm baseline import (dpp-realm.json) with frontend/backend clients and realm roles
- Backend JWT validation primitives and FastAPI auth dependencies for future protected routes
- Settings contract for issuer, audience, algorithm, and derived OIDC/JWKS endpoints
- Unit tests for configuration and JWT claim/role validation behavior
- Local environment hardening with .aas_py virtual environment workflow and tooling docs
- Traefik local routing fallback using file provider (infra/traefik/dynamic.yml) to avoid Docker provider instability on Docker Desktop

Validation run locally:
- .aas_py\\Scripts\\python -m pytest tests/unit/test_config.py tests/unit/test_keycloak_auth.py tests/integration/test_health_endpoints.py -ra
- .aas_py\\Scripts\\python -m ruff check app tests
- route checks via Traefik for localhost, dpp.localhost, and api.dpp.localhost

Closes #8